### PR TITLE
Remove user roles table

### DIFF
--- a/persistence/src/main/resources/schema.sql
+++ b/persistence/src/main/resources/schema.sql
@@ -35,9 +35,3 @@ CREATE TABLE IF NOT EXISTS orders_items
   dishid   INTEGER NOT NULL,
   quantity INTEGER NOT NULL
 );
-
-CREATE TABLE IF NOT EXISTS user_roles
-(
-  userid   INTEGER NOT NULL,
-  role     VARCHAR(30)
-);

--- a/persistence/src/test/resources/schema.sql
+++ b/persistence/src/test/resources/schema.sql
@@ -35,9 +35,3 @@
 --   dishid   INTEGER NOT NULL,
 --   quantity INTEGER NOT NULL
 -- );
---
--- CREATE TABLE IF NOT EXISTS "user_roles"
--- (
---   userid INTEGER NOT NULL,
---   role   VARCHAR(30)
--- );


### PR DESCRIPTION
```
CREATE TABLE IF NOT EXISTS user_roles
(
  userid   INTEGER NOT NULL,
  role     VARCHAR(30)
);
```

Already addressed in second iteration release. See comment on README.md:

> ALTER TABLE public.user_roles RENAME TO user_role;